### PR TITLE
Remove `docker.io/library/` from image names

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 ARG php="8.2"
 
 ## Base PHP images
-FROM docker.io/library/php:8.0-fpm-alpine@sha256:8c29a2403a1067239d7496542789573e782d8be283c7f43178bed124f293f6a0 AS php8.0
-FROM docker.io/library/php:8.1-fpm-alpine@sha256:a402fe4a2a089932dfbcdd74e320731f77ef664443315ce40fa7129f942212ec AS php8.1
-FROM docker.io/library/php:8.2-fpm-alpine@sha256:922fa9038781e96eca5faabf57ff4e23821c1956047da32d98c78023cc006f57 AS php8.2
+FROM php:8.0-fpm-alpine@sha256:8c29a2403a1067239d7496542789573e782d8be283c7f43178bed124f293f6a0 AS php8.0
+FROM php:8.1-fpm-alpine@sha256:a402fe4a2a089932dfbcdd74e320731f77ef664443315ce40fa7129f942212ec AS php8.1
+FROM php:8.2-fpm-alpine@sha256:922fa9038781e96eca5faabf57ff4e23821c1956047da32d98c78023cc006f57 AS php8.2
 
 ## Helper images
 FROM blackfire/blackfire:2@sha256:c58e3d1778fa34c35f92c9fb5a893f8d4c6e9740f38f61330a27636270fcaf1f AS blackfire

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -4,7 +4,7 @@ mapfile -t versions < <(grep -E '^FROM .* AS php[0-9\.]+$' Dockerfile | cut -f 4
 
 for version in "${versions[@]}"; do
 	image=$(grep "AS ${version}" Dockerfile | cut -f 2 -d ' ' | cut -f 1 -d @)
-	new=$(docker manifest inspect -v "${image}" | jq -r '.[0].Ref')
+	new=$(docker manifest inspect -v "${image}" | jq -r '.[0].Ref' | sed -s 's#^docker\.io/\(library/\)\?##')
 
 	sed -i "s#FROM .*AS ${version}#FROM ${new} AS ${version}#" Dockerfile
 done


### PR DESCRIPTION
They work but we are used to just seeing them without.
