### PR TITLE
Use `PHP_DOCUMENT_ROOT` as PHP's document root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,10 @@ RUN apk add --no-cache bash=~5 git=~2 jq=~1 mariadb-client=~10 msmtp=~1 patch=~2
     install-php-extensions ${php_enable_extensions} && \
     IPE_DONT_ENABLE=1 install-php-extensions ${php_install_extensions}
 
+ARG workdir=/var/www
+WORKDIR "${workdir}"
+ENV PHP_DOCUMENT_ROOT="${workdir}/web"
+
 ENV PHP_SENDMAIL_PATH="/usr/bin/msmtp --read-recipients --read-envelope-from"
 
 ENTRYPOINT [ "reload-php-entrypoint" ]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Work in progress.
 - [ ] Documentation on how to use
 - [ ] Documentation on the philosophie behind the images
 - [ ] Documentation on how to migrate from [old Reload images](https://github.com/reload/docker-drupal-php7-fpm)
-- [ ] Find better way to determine document root
+- [x] Find better way to determine document root
 - [ ] Drupal specific configuration (I know how I want this done)
 - [x] Blackfire integration
 - [x] Xdebug integration

--- a/context/usr/local/bin/reload-php-entrypoint
+++ b/context/usr/local/bin/reload-php-entrypoint
@@ -1,13 +1,9 @@
 #!/bin/sh
 
-mkdir -p /etc/entrypoint.d
-
 for feature in $USE_FEATURES; do
 	[ -x "/etc/features.d/$feature" ] && "/etc/features.d/$feature"
 done
 
 /bin/run-parts --exit-on-error /etc/entrypoint.d
-
-cd "$(find . -maxdepth 1 -mindepth 1 \( -name html -o -name docroot -o -name web \) -print)" || true
 
 /usr/local/bin/docker-php-entrypoint "$@"


### PR DESCRIPTION
We default to `/var/www/web` because that's the existnig convention in
Reload.
