### PR TITLE
Add an init process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ COPY --from=blackfire /usr/local/bin/blackfire /usr/bin
 COPY --from=composer /usr/bin/composer /usr/bin
 COPY --from=php-extension-installer /usr/bin/install-php-extensions /usr/bin
 
-RUN apk add --no-cache bash=~5 git=~2 jq=~1 mariadb-client=~10 msmtp=~1 patch=~2 unzip=~6 graphicsmagick=~1 && \
+RUN apk add --no-cache bash=~5 git=~2 jq=~1 mariadb-client=~10 msmtp=~1 patch=~2 unzip=~6 graphicsmagick=~1 tini=~0 && \
     install-php-extensions ${php_enable_extensions} && \
     IPE_DONT_ENABLE=1 install-php-extensions ${php_install_extensions}
 
@@ -36,5 +36,5 @@ ENV PHP_DOCUMENT_ROOT="${workdir}/web"
 ENV COMPOSER_CACHE_DIR="/tmp/composer-cache"
 ENV PHP_SENDMAIL_PATH="/usr/bin/msmtp --read-recipients --read-envelope-from"
 
-ENTRYPOINT [ "reload-php-entrypoint" ]
-CMD [ "php-fpm" ]
+ENTRYPOINT [ "/sbin/tini", "--" ]
+CMD [ "reload-php-entrypoint", "php-fpm" ]

--- a/context/usr/local/bin/reload-php-entrypoint
+++ b/context/usr/local/bin/reload-php-entrypoint
@@ -6,4 +6,4 @@ done
 
 /bin/run-parts --exit-on-error /etc/entrypoint.d
 
-/usr/local/bin/docker-php-entrypoint "$@"
+exec /usr/local/bin/docker-php-entrypoint "$@"


### PR DESCRIPTION
Without an init process, the SIGQUIT from docker isn't forwarded to the right process, and we'll have to wait for docker to get impatient and SIGTERMing everything.

Also, exec `docker-php-entrypoint` to make it take our script's place. Eliminates one process and keeps things tidy, as `docker-php-entrypoint` does the same thing with fpm.
