### PR TITLE
Move entrypoint script into entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,5 +42,5 @@ ENV PATH="${workdir}/vendor/bin:${PATH}"
 ENV PHP_DOCUMENT_ROOT="${workdir}/web"
 ENV PHP_SENDMAIL_PATH="/usr/bin/msmtp --read-recipients --read-envelope-from"
 
-ENTRYPOINT [ "/sbin/tini", "--" ]
-CMD [ "reload-php-entrypoint", "php-fpm" ]
+ENTRYPOINT [ "/sbin/tini", "--", "reload-php-entrypoint" ]
+CMD [ "php-fpm" ]


### PR DESCRIPTION
Otherwise, the features functionality and upstart scripts would not be run when using e.g. `docker run --rm -it ghcr.io/reload/php-fpm:8.2 ls`.
