### PR TITLE
Use Dependabot for the PHP images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,9 @@ updates:
       - "reload/developers"
     ignore:
       - dependency-name: "php"
+        update-times: ["version-update:semver-major", "version-update:semver-minor", "version-update:semver-patch"]
       - dependency-name: "library/php"
+        update-times: ["version-update:semver-major", "version-update:semver-minor", "version-update:semver-patch"]
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
According to https://github.com/dependabot/dependabot-core/issues/1971
and https://github.com/dependabot/dependabot-core/pull/6628 it should
be possible to update only the SHA's now.

We'll leave our existing update mechanism in place until we have seen
whether Dependabot will actually do what we expect / hope for.
