### PR TITLE
Add EOL warnings in startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ FROM mlocati/php-extension-installer:2@sha256:c3a2b786a0ed48919fea7af99bbc2732e5
 # hadolint ignore=DL3006
 FROM php${php}
 
+ARG php=${php}
 ARG php_enable_extensions="apcu bcmath calendar ctype curl dom exif fileinfo ftp gd gettext iconv imagick intl json mbstring memcache memcached mysqli mysqlnd opcache pdo pdo_mysql pdo_sqlite phar posix readline redis shmop simplexml soap sockets sqlite3 sysvmsg sysvsem sysvshm tokenizer xml xmlreader xmlwriter xsl zip"
 ARG php_install_extensions="blackfire xdebug"
 
@@ -32,6 +33,9 @@ RUN <<EOT
     adduser -H -D -S -G wheel -u 501 machost
     adduser -H -D -S -G wheel -u 1000 linuxhost
 EOT
+
+SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
+RUN curl https://endoflife.date/api/php/${php}.json| jq '{support,eol,lts}' > /etc/eol.json
 
 ARG workdir=/var/www
 WORKDIR "${workdir}"

--- a/context/etc/entrypoint.d/eol.sh
+++ b/context/etc/entrypoint.d/eol.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+TODAY=$(date +%Y-%m-%d)
+SUPPORT=$(jq -r .support /etc/eol.json)
+EOL=$(jq -r .eol /etc/eol.json)
+
+if [[ "$TODAY" > "$SUPPORT" ]]; then
+	echo "" >&2
+	echo "###############################################" >&2
+	echo "##" >&2
+	echo "## This version of PHP is unsupported. Please upgrade to a supported version." >&2
+	echo "##" >&2
+	echo "###############################################" >&2
+	echo "" >&2
+fi
+
+if [[ "$TODAY" > "$EOL" ]]; then
+	echo "" >&2
+	echo "###############################################" >&2
+	echo "##" >&2
+	echo "## This version of PHP has reached end of life and no longer receives security updates. Please upgrade to a supported version." >&2
+	echo "##" >&2
+	echo "###############################################" >&2
+	echo "" >&2
+fi


### PR DESCRIPTION
_Up for discussion:_

Should we let the container emit warnings on startup if we have passed the PHP version's end-of-support and end-of-life dates?

~~Should the warnings be “noisier”?~~