### PR TITLE
Use full path to repository php.ini

### DIFF
--- a/context/etc/features.d/root-php-ini
+++ b/context/etc/features.d/root-php-ini
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-if [ -r php.ini ]; then
+if [ -r /var/www/php.ini ]; then
 	sudo ln -f -s "$(readlink -f php.ini)" "$(php-config --ini-dir)/000-php.ini"
 fi


### PR DESCRIPTION
If the container is configured with another working_dir than `/var/www`, then the root-php-ini script fails to see the php.ini file.