### PR TITLE
Multiarch images

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -39,6 +39,8 @@ jobs:
           context: .
           platforms: ${{ matrix.platform }}
           build-args: "php=${{ matrix.php }}"
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           labels: |
             org.opencontainers.image.title=PHP ${{ matrix.php }}
             org.opencontainers.image.description=Docker image for PHP ${{ matrix.php }} FPM

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,8 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           build-args: "php=${{ matrix.php }}"
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           labels: |
             org.opencontainers.image.title=PHP ${{ matrix.php }}
             org.opencontainers.image.description=Docker image for PHP ${{ matrix.php }} FPM

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,6 @@ HEALTHCHECK --interval=10s --start-period=90s CMD netstat -ltn | grep -c ":9000"
 
 COPY context/ /
 
-COPY --from=blackfire /usr/local/bin/blackfire /usr/bin
-COPY --from=composer /usr/bin/composer /usr/bin
 COPY --from=php-extension-installer /usr/bin/install-php-extensions /usr/bin
 
 RUN <<EOT
@@ -35,6 +33,9 @@ RUN <<EOT
     adduser -H -D -S -G wheel -u 501 machost
     adduser -H -D -S -G wheel -u 1000 linuxhost
 EOT
+
+COPY --from=blackfire /usr/local/bin/blackfire /usr/bin
+COPY --from=composer /usr/bin/composer /usr/bin
 
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 RUN curl https://endoflife.date/api/php/${php}.json| jq '{support,eol,lts}' > /etc/eol.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 ARG php="8.2"
 
 ## Base PHP images
-FROM php:8.0-fpm-alpine@sha256:173daec831fa47844c876258a19741c7a1928524b5e1936a2b1e7c1f58ec1b12 AS php8.0
-FROM php:8.1-fpm-alpine@sha256:a13add2aa7bdf1debe91ec56ba951823261295c907e00c2b6ffec69e842ba992 AS php8.1
-FROM php:8.2-fpm-alpine@sha256:747e3f4843c75203c5e6aff70429368048cbeaa2a6e79b81f1a4e700b9e05add AS php8.2
-FROM php:8.3-fpm-alpine@sha256:dc3e7bef05e4e8960d1138bd6da361a05a073e0bd40cd072144691d71ec5b834 AS php8.3
+FROM php:8.0-fpm-alpine@sha256:bbf76d84a693fae1e0d2a259db70c9c47f41bd5a6ec3d339ba397939e7875dd8 AS php8.0
+FROM php:8.1-fpm-alpine@sha256:d25c61d176d62c1929bd1d155fc4073b5d8d0db3f4a2d1ae67f580439409fc7f AS php8.1
+FROM php:8.2-fpm-alpine@sha256:a16bc43404e602adb0f8f9662a1319f83d85daf23110bf7e02152a8a0e3d7e5e AS php8.2
+FROM php:8.3-fpm-alpine@sha256:421373ae5f16b3afa03506de0ecbb4dcf39e4fe817b2a40b5f5c1f23c041dffa AS php8.3
 
 ## Helper images
 FROM blackfire/blackfire:2@sha256:a701c54bdba874443b76ce27d2a6fbbe30e8ee517eb38823df4337b3461eef69 AS blackfire

--- a/bin/update-php-images-sha.sh
+++ b/bin/update-php-images-sha.sh
@@ -6,6 +6,7 @@ mapfile -t versions < <(grep -E '^FROM .* AS php[0-9\.]+$' Dockerfile | cut -f 4
 
 for version in "${versions[@]}"; do
 	image=$(grep "AS ${version}" Dockerfile | cut -f 2 -d ' ' | cut -f 1 -d @)
-	new=$(docker buildx imagetools inspect --raw "${image}" | jq -r '.manifests[0].digest')
+	docker pull "${image}"
+	new=$(docker image inspect "${image}" | jq -r '.[0].RepoDigests[0]' | cut -f 2 -d @)
 	sed -i "s#FROM .*AS ${version}#FROM ${image}@${new} AS ${version}#" Dockerfile
 done


### PR DESCRIPTION
Builds in GitHub Actions warned that the SHA's in the Dockerfile referenced AMD version when building the ARM versions.

This pull request changes the PHP images to references a multiarch SHA and thus avoids that complaint.

The increases the build time of the ARM images dramatically! They used to build in 3–4 minutes, but now it takes 35–45 minutes! I have no clue why. The AMD images still build in 3–4 minutes.

To mitigate the long build time, I introduced caching of docker layers (based on https://docs.docker.com/build/ci/github-actions/cache/). A cached rebuild is now down 3–4 seconds.

I also reordered some instructions in the Dockerfile so that we'll be able to reuse the cached layers more often (when updating the Blackfire CLI and the composer CLI) and only suffer the long build time when we update the base PHP images.

The Dockerfile still references AMD image SHA's for the Blackfire CLI, the composer CLI, and the mlocati/php-extension-installer CLI.

Those are updated by @dependabot, and I haven't figured out if we can make Dependabot use the multiarch SHA's.