### PR TITLE
Minor tunings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,6 @@ FROM php${php}
 
 ARG php=${php}
 ARG php_enable_extensions="apcu bcmath calendar ctype curl dom exif fileinfo ftp gd gettext iconv imagick intl json mbstring memcache memcached mysqli mysqlnd opcache pdo pdo_mysql pdo_sqlite phar posix readline redis shmop simplexml soap sockets sqlite3 sysvmsg sysvsem sysvshm tokenizer xml xmlreader xmlwriter xsl zip"
-ARG php_install_extensions="blackfire xdebug"
 
 HEALTHCHECK --interval=10s --start-period=90s CMD netstat -ltn | grep -c ":9000"
 
@@ -29,7 +28,8 @@ RUN <<EOT
     set -eux
     apk add --no-cache bash=~5 git=~2 jq=~1 mariadb-client=~11 msmtp=~1 patch=~2 unzip=~6 graphicsmagick=~1 sudo=~1 tini=~0
     install-php-extensions ${php_enable_extensions}
-    if [ "${php}" != "8.4" ]; then IPE_DONT_ENABLE=1 install-php-extensions ${php_install_extensions}; fi
+    if [ "${php}" != "8.4" ]; then IPE_DONT_ENABLE=1 install-php-extensions blackfire; fi
+    IPE_DONT_ENABLE=1 install-php-extensions xdebug
     adduser -H -D -S -G wheel -u 501 machost
     adduser -H -D -S -G wheel -u 1000 linuxhost
 EOT

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG php="8.2"
+ARG php="8.3"
 
 ## Base PHP images
 FROM php:8.1-fpm-alpine@sha256:e47e95fff703c5d51ef8b9d8c2bbc9a0fa21d7b2612338ed31a9395ba619758b AS php8.1

--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ The images come with the following extensions installed and enabled:
 - xsl
 - zip
 
-In addition, the `xdebug` and `blackfire` extensions are installed but
-not enabled in the images (except on PHP 8.4).
+In addition, the `blackfire` (except on PHP 8.4) and `xdebug`
+extensions are installed but not enabled in the images.
 
 The
 [php-extension-installer](https://github.com/mlocati/docker-php-extension-installer)


### PR DESCRIPTION
- **Default to PHP 8.3 if not specified**
- **Xdebug extension is now installable on PHP 8.4**
