### PR TITLE
Use `bookworm` instead of `alpine` as base

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ services:
 
 We provide PHP 8.1, 8.2, 8.3 and 8.4 images.
 
-The images are based on the official [`php:8.x-fpm-alpine` Docker
+The images are based on the official [`php:8.x-fpm-bookworm` Docker
 images](https://hub.docker.com/_/php). We build new images when new
 upstream versions are released.
 


### PR DESCRIPTION
The Alpine images use`musl` library, and `musl` has limited
localization support (see <https://wiki.musl-libc.org/open-issues#Locale_limitations>). Especially since there is no sorting of Danish strings.

Being able to do Danish sorting is essential for our projects. So we'll switch to Debian bookworm-based images, which use `glibc` and install all locales.

This will result in larger Docker images, though.
