### PR TITLE
Support for the Blackfire extension on PHP 8.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,7 @@ RUN <<EOT
     set -eux
     apk add --no-cache bash=~5 git=~2 jq=~1 mariadb-client=~11 msmtp=~1 patch=~2 poppler-utils=~24 unzip=~6 graphicsmagick=~1 sudo=~1 tini=~0
     install-php-extensions ${php_enable_extensions}
-    if [ "${php}" != "8.4" ]; then IPE_DONT_ENABLE=1 install-php-extensions blackfire; fi
-    IPE_DONT_ENABLE=1 install-php-extensions xdebug
+    IPE_DONT_ENABLE=1 install-php-extensions blackfire xdebug
     adduser -H -D -S -G wheel -u 501 machost
     adduser -H -D -S -G wheel -u 1000 linuxhost
 EOT

--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ The images come with the following extensions installed and enabled:
 - xsl
 - zip
 
-In addition, the `blackfire` (except on PHP 8.4) and `xdebug`
-extensions are installed but not enabled in the images.
+In addition, the `blackfire` and `xdebug` extensions are installed but
+not enabled in the images.
 
 The
 [php-extension-installer](https://github.com/mlocati/docker-php-extension-installer)


### PR DESCRIPTION
See https://github.com/mlocati/docker-php-extension-installer/pull/1077
