### PR TITLE
Add PHP 8.5 to supported versions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ services:
 
 ## PHP versions
 
-We provide PHP 8.1, 8.2, 8.3 and 8.4 images.
+We provide PHP 8.1, 8.2, 8.3, 8.4, and 8.5 images (an 8.0 image is still
+published, but is unsupported).
 
 The images are based on the official [`php:8.x-fpm-alpine` Docker
 images](https://hub.docker.com/_/php). We build new images when new


### PR DESCRIPTION
Updated PHP versions list to include 8.5 and note unsupported 8.0.