### PR TITLE
Change Dependabot schedule from daily to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,5 +12,5 @@ updates:
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: daily
+      interval: monthly
       timezone: Europe/Copenhagen


### PR DESCRIPTION
But only for GitHub Actions dependencies. Dependencies for the Dockerfile we still want on a daily basis.